### PR TITLE
Update for corebird >= 0.7

### DIFF
--- a/messagingmenu@screenfreeze.net/extension.js
+++ b/messagingmenu@screenfreeze.net/extension.js
@@ -58,6 +58,7 @@ let compatible_MBlogs = [
 	"friends-app",
 	"gfeedline",
 	"corebird",
+	"org.baedert.corebird",
 	"heybuddy"
 ];
 let compatible_Emails = [


### PR DESCRIPTION
In recent versions of corebird the name of the desktop files has changed to org.baedert.corebird.desktop
