### PR TITLE
Add support for Tox clients: qTox, muTox and Venom

### DIFF
--- a/messagingmenu@screenfreeze.net/extension.js
+++ b/messagingmenu@screenfreeze.net/extension.js
@@ -41,7 +41,10 @@ let compatible_Chats = [
 	"qutim",
 	"amsn",
 	"openfetion",
-	"org.gnome.Polari"
+	"org.gnome.Polari",
+	"qtox",
+	"utox",
+	"venom"
 ];
 let compatible_MBlogs = [
 	"gwibber",


### PR DESCRIPTION
Hi, 

Just as the the title say, adding [Venom](https://github.com/naxuroqa/Venom), [Tox](http://tox.im) client.
There are [more clients](https://wiki.tox.im/Clients) but this is the only one I tested.
