### PR TITLE
Add 3.14.1 to list of compatible versions

### DIFF
--- a/messagingmenu@screenfreeze.net/metadata.json
+++ b/messagingmenu@screenfreeze.net/metadata.json
@@ -2,7 +2,8 @@
 "shell-version": [
 	"3.9",
 	"3.10",
-	"3.12"
+	"3.12",
+	"3.14.1"
 ],
 "uuid": "messagingmenu@screenfreeze.net",
 "name": "Messaging Menu",


### PR DESCRIPTION
The extension works correctly for me with Gnome 3.14.1 on Arch Linux. 

Thanks for the good work!
